### PR TITLE
Removed @csrf_exempt from put request.

### DIFF
--- a/dashboardAPI/dashboardAPI/views.py
+++ b/dashboardAPI/dashboardAPI/views.py
@@ -26,7 +26,6 @@ def get_issue_events(request, **kwargs):
         print(f"Error getting issues: {error}")
         return HttpResponseBadRequest
 
-@csrf_exempt
 @api_view(["PUT"])
 def update_issue_status(request, **kwargs):
     URI = f"{SENTRY_URI}/organizations/{SENTRY_ORGANIZATION_SLUG}/issues/{kwargs.get("issue_id")}/"


### PR DESCRIPTION
Needed to exempt `update_issue_status` from csrf requirements in previous version due to missing `@api_view` decorator. Removed to avoid security issues caused by csrf exemption.