### PR TITLE
Fixed a sentry uri (added trailing /)

### DIFF
--- a/dashboardAPI/dashboardAPI/views.py
+++ b/dashboardAPI/dashboardAPI/views.py
@@ -68,7 +68,7 @@ def get_issues(request, **kwargs):
 
 @api_view(["GET"])
 def get_events(request, **kwargs):
-    URI = f"{SENTRY_URI}/projects/{SENTRY_ORGANIZATION_SLUG}/{SENTRY_PROJECT_ID}/events"
+    URI = f"{SENTRY_URI}/projects/{SENTRY_ORGANIZATION_SLUG}/{SENTRY_PROJECT_ID}/events/"
     try:
         response = requests.get(URI, headers = HEADERS)
         response.raise_for_status() # Raise HTTPError for bad responses (4xx or 5xx)


### PR DESCRIPTION
Fixed sentry URI in django (the missing trailing / caused an error on access).