### PR TITLE
Fix docker, rebuild scripts, and add documentation

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -145,7 +145,7 @@ In the case that the rebuild script does not work correctly, development can be 
    - Found in Settings → API Keys
 
 ### Docker Configuration
-The application uses Docker Compose for containerization, which is configured in [compose.yml](compose.yml).
+The application uses Docker Compose for containerization, which is configured in [compose.yml](compose.yml). [Docker compose](compose.yml) uses [dashboard-ui/Dockerfile](dashboard-ui/Dockerfile) and [dashboardAPI/Dockerfile](dashboardAPI/Dockerfile) in order to build each image. Both `Dockerfiles` are multistage in order to both make the build contingent on passing test cases and take advantage of [Docker build caching](https://docs.docker.com/build/cache/) to speed up the build process.
 
 ## Usage Guide
 

--- a/dashboardAPI/Dockerfile
+++ b/dashboardAPI/Dockerfile
@@ -8,6 +8,11 @@ ENV PYTHONUNBUFFERED=1
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
-FROM base AS final
+FROM base AS test
+WORKDIR /dashboard-backend
 EXPOSE 8000
+RUN ["python", "manage.py", "test", "--parallel"]
+
+
+FROM test AS final
 CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,4 +1,4 @@
-USAGE="Usage: ./rebuild.sh ?[ frontend / f / backend / b / test]"
+USAGE="Usage: ./rebuild.sh ?[ frontend / f / backend / b ]"
 
 # Stop and rebuild
 if [ "$#" -eq 0 ]; then
@@ -10,10 +10,6 @@ elif [ "$#" -eq 1 ]; then
 		SERVICE="frontend"
     elif [ $1 = "backend" ] || [ $1 = "b" ]; then
 		SERVICE="backend"
-    elif [ $1 = "test" ]; then
-        echo "Running backend tests..."
-        docker compose exec backend python manage.py test --parallel
-        exit 0
     else
         echo -e $USAGE
         exit 0


### PR DESCRIPTION
Fixed [dashboardAPI/Dockerfile](dashboardAPI/Dockerfile) to run tests as part of a multistage build process, removed the test option in [rebuild.sh](rebuild.sh), and added documentation for Dockerfiles.